### PR TITLE
Remove unnecessary task spawn in `process()`

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -67,18 +67,17 @@ async fn process(
                 Err(e) => warn!("Unable to establish peer protocol: {}", e),
                 Ok(client) => {
                     info!("Established peer protocol");
-                    tokio::spawn(
-                        async move {
-                            let mut worker = Worker::new(client, tx, completion_rx, queue);
-                            match worker.download().await {
-                                Err(e) => warn!("Encountered error during download: {}", e),
-                                Ok(_) => {
-                                    info!("Successful download")
-                                }
-                            };
-                        }
-                        .instrument(tracing::Span::current()),
-                    );
+                    async move {
+                        let mut worker = Worker::new(client, tx, completion_rx, queue);
+                        match worker.download().await {
+                            Err(e) => warn!("Encountered error during download: {}", e),
+                            Ok(_) => {
+                                info!("Successful download")
+                            }
+                        };
+                    }
+                    .instrument(tracing::Span::current())
+                    .await;
                 }
             };
         }


### PR DESCRIPTION
Futures returned by the `process()` function are spawned as tasks in the loop over peers in the `download()` function, so parallel execution of the futures representing the `process()` function will be possible (once the multi-threaded runtime is enabled, see #14).

Due to the future values representing the entire `process()` function being spawned as tasks, there isn't much need to spawn the future value which is returned by the innermost `match`'s `Ok` arm as a task, since the "parent future" returned by `process()` is already able to execute in parallel with the other futures that are created by the call to `process()` in the loop in `download()`.

Another way to say this is that, because there's not many levels of future-nesting between:
- the top-level of `process()`
- the innermost `match` in `process()`

having parallelism across futures returned by the innermost `match`'s `Ok` arm is not providing much extra on top of the parallelism available across futures returned by `process()`.