### PR TITLE
Change `loop` + `if` for breaking out of iteration, to `while` loop

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -40,7 +40,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Worker<T> {
 
         let timeout_interval = tokio::time::Duration::from_secs(15);
         let mut time_since_last_keep_alive = None;
-        loop {
+        while !*self.completion_receiver.borrow() {
             while let Some(work) = self.work_queue.dequeue() {
                 if !self.client.bitfield.has_piece(work.index as usize) {
                     self.work_queue.enqueue(work);
@@ -76,10 +76,6 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Worker<T> {
                 } else {
                     self.work_queue.enqueue(work);
                 }
-            }
-
-            if *self.completion_receiver.borrow() {
-                break;
             }
 
             match time_since_last_keep_alive {


### PR DESCRIPTION
The behaviour after this change is largely the same as before (a keep-alive message may be unnecessarily sent to the peer, which is a small difference), but the intention behind the iteration is clearer when written as a `while` loop with a condition, rather than a `loop` with an `if` block buried within the body of the `loop` for breaking out of the iteration.